### PR TITLE
Update sa if name/namespace/labels/annotations change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
+	k8s.io/api v0.20.1
 	k8s.io/apimachinery v0.20.1
 	k8s.io/client-go v0.20.1
 )

--- a/main.go
+++ b/main.go
@@ -117,6 +117,7 @@ func Main() int {
 		cl = client.NewClient(konfig, klient)
 		cl.WithLogger(log.With(logger, "component", "client"))
 		cl.SetUpdatePreparations(client.DefaultUpdatePreparations)
+		cl.SetUpdateChecks(client.DefaultUpdateChecks)
 	}
 
 	sources := map[string]func() ([]byte, error){}


### PR DESCRIPTION
Update ServiceAccount leads to create secret per time. so you will see many secrets created in your environment if there are some reconciles triggered.

https://github.com/open-cluster-management/backlog/issues/11093

Signed-off-by: clyang82 <chuyang@redhat.com>

/assign @brancz 