### PR TITLE
Added an option to do one trigger run for the whole DB result set instead of one trigger per row

### DIFF
--- a/trigger/database/database.go
+++ b/trigger/database/database.go
@@ -154,7 +154,7 @@ func (t *TriggerRunner) checkTrigger(ctx context.Context, c TriggerConfig) error
 	}
 }
 
-func (t *TriggerRunner) ScheduleTriggerRun(ctx context.Context, triggerName, key string, payload []byte) error {
+func (t *TriggerRunner) ScheduleTriggerRun(ctx context.Context, triggerName, key string, payload []byte) {
 	if _, ok := t.activeTriggers[key]; !ok {
 		run := &TriggerRun{
 			logger: t.logger,
@@ -166,8 +166,6 @@ func (t *TriggerRunner) ScheduleTriggerRun(ctx context.Context, triggerName, key
 
 		go run.Run(ctx, payload)
 	}
-
-	return nil
 }
 
 func (t *TriggerRunner) cockroachTrigger(ctx context.Context, conn *crdb.Client, c TriggerConfig) error {
@@ -222,9 +220,7 @@ func (t *TriggerRunner) cockroachTrigger(ctx context.Context, conn *crdb.Client,
 					return err
 				}
 
-				if err := t.ScheduleTriggerRun(ctx, c.Name, triggerKey, payload); err != nil {
-					return err
-				}
+				t.ScheduleTriggerRun(ctx, c.Name, triggerKey, payload)
 			} else {
 				rowsArray = append(rowsArray, row)
 			}
@@ -236,10 +232,7 @@ func (t *TriggerRunner) cockroachTrigger(ctx context.Context, conn *crdb.Client,
 				return err
 			}
 
-			if err := t.ScheduleTriggerRun(ctx, c.Name, groupTriggerKey, payload); err != nil {
-				return err
-			}
-
+			t.ScheduleTriggerRun(ctx, c.Name, groupTriggerKey, payload)
 		}
 
 		return nil

--- a/trigger/database/database.go
+++ b/trigger/database/database.go
@@ -185,7 +185,6 @@ func (t *TriggerRunner) cockroachTrigger(ctx context.Context, conn *crdb.Client,
 		}
 
 		rowsArray := make([]map[string]any, 0)
-		groupTriggerKey := ""
 		for rows.Next() {
 			row := make(map[string]any, len(columns))
 
@@ -212,7 +211,6 @@ func (t *TriggerRunner) cockroachTrigger(ctx context.Context, conn *crdb.Client,
 			default:
 				triggerKey = fmt.Sprintf("%v", key)
 			}
-			groupTriggerKey += triggerKey
 
 			if !c.GroupsRowsToArray {
 				payload, err := json.Marshal(row)
@@ -232,7 +230,7 @@ func (t *TriggerRunner) cockroachTrigger(ctx context.Context, conn *crdb.Client,
 				return err
 			}
 
-			t.ScheduleTriggerRun(ctx, c.Name, groupTriggerKey, payload)
+			t.ScheduleTriggerRun(ctx, c.Name, "", payload)
 		}
 
 		return nil


### PR DESCRIPTION
This change allows users to pass a `GroupsRowsToArray` flag in the DB trigger config, which will then pass the whole result set as payload to the trigger instead of running one trigger per row. 